### PR TITLE
Use correct option name in azure settings #5

### DIFF
--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -142,7 +142,7 @@ class BlobStore:
                     )
                 return BlobServiceClient.from_connection_string(connection_string)
 
-            elif auth_method == "Account Access Key":
+            elif auth_method == "Access Key":
                 account_name = self.settings.storage_account_name
                 access_key = self.settings.get_password("access_key")
                 if not account_name or not access_key:


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->
This PR fixes a bug in the Azure Blob Storage authentication logic.

The code was checking for the authentication method string `"Account Access Key"`, but the actual value saved by the configuration (likely from a Select field) is `"Access Key"`. This mismatch caused the initialization of the `BlobServiceClient` to fail when using an Account Access Key.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->
* **String Correction**: Updated the conditional check from `elif auth_method == "Account Access Key":` to `elif auth_method == "Access Key":` to match the actual configuration value.

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

1. **Configure Azure Settings:**
   * Go to **Azure Blob Storage Settings**.
   * Set **Authentication Method** to **"Access Key"**.
   * Enter a valid Storage Account Name and Access Key.
   * Save the settings.

2. **Test Connection/Upload:**
   * Upload a file to a DocType configured to use Azure Blob Storage.
   * **Expected Result:** The file uploads successfully without authentication errors.
   * **Prior to Fix:** The upload would likely fail or fall through to an error state because the client wasn't initialized correctly.

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->
N/A

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
N/A

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.

Fixes: #3 
Ref: https://github.com/rtCamp/frappe-azure-blob-storage/pull/5