### PR TITLE
refactor: improve on_update event handler to return early for ignoreddata types

### DIFF
--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -25,16 +25,17 @@ def on_update(doc, method):
     Event handler for the 'on_update' event of the File document.
     This function is used to update the File URL if the file is stored in Azure Blob Storage.
     """
-    blob_store = BlobStore()
     if (
         doc.flags.in_insert  # ignore if this is a new file being inserted
         or not doc.has_value_changed("is_private")
         or BlobStore.is_local_file(doc.file_url)
-        or blob_store.is_ignored_dtype(doc.attached_to_doctype)
     ):
         return
 
     blob_store = BlobStore()
+    if blob_store.is_ignored_dtype(doc.attached_to_doctype):
+        return
+
     blob_name = blob_store.parse_url(doc.file_url)
     if not blob_name:
         generate_error_log(

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -32,6 +32,9 @@ def on_update(doc, method):
     ):
         return
 
+    settings = frappe.get_single("Azure Storage Settings")
+    if not settings.auto_upload_to_azure:
+        return
     blob_store = BlobStore()
     if blob_store.is_ignored_dtype(doc.attached_to_doctype):
         return


### PR DESCRIPTION
## Description

- This PR fixes a error that originates even when Azure Blob Storage is disabled in settings. 


### AI Summary

This pull request refactors the `on_update` event handler in `frappe_azure_blob_storage/doc_events/file.py` to improve efficiency and correctness. The main change is to delay the instantiation of the `BlobStore` object until after initial early returns, and to ensure that the `is_ignored_dtype` check is performed only when necessary.

**Event handler logic improvements:**

* Moved the instantiation of `BlobStore` in `on_update` to occur only after confirming the update is relevant, reducing unnecessary object creation.
* Changed the order of checks so that `blob_store.is_ignored_dtype(doc.attached_to_doctype)` is only called after confirming the file is not local and other early exit conditions are not met, improving efficiency and logic clarity.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #