### PR TITLE
Add Ignored DocTypes and override File.get_content for Azure blobs with v16 compat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.14.10
     hooks:
       - id: ruff
         name: "Run ruff import sorter"
@@ -39,10 +39,20 @@ repos:
         always_run: true
 
   - repo: https://github.com/semgrep/pre-commit
-    rev: 'v1.91.0'
+    rev: "v1.149.0"
     hooks:
       - id: semgrep-ci
-        args: ['--config', './.frappe-semgrep/rules', '--config','r/python.lang.correctness','--error', '--skip-unknown-extensions', '--metrics','off']
+        args:
+          [
+            "--config",
+            "./.frappe-semgrep/rules",
+            "--config",
+            "r/python.lang.correctness",
+            "--error",
+            "--skip-unknown-extensions",
+            "--metrics",
+            "off",
+          ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/frappe_azure_blob_storage/api/azure_blob.py
+++ b/frappe_azure_blob_storage/api/azure_blob.py
@@ -157,8 +157,10 @@ def _run_migrate_job(files_list: list | None = None, is_web_request: bool = True
             print(f"\nERROR: Migration failed. Check Error Log for details.\n{frappe.get_traceback()}")
 
 
-@frappe.whitelist(methods=["GET"])
-def download_private_file(file_name: str):
+@frappe.whitelist(methods=["GET"], allow_guest=True)  # nosemgrep
+def download_file(file_name: str):
+    from frappe.utils.response import download_private_file
+
     """
     A proxy method to securely download private files from Azure.
     It checks file permissions and then redirects to a temporary SAS URL.
@@ -170,38 +172,38 @@ def download_private_file(file_name: str):
             file_name = file_name.split("?fid=")[0]
 
         # 1. Get the File document
-        file_url = BlobStore.get_private_file_link(file_name)
-        file_doc = frappe.get_doc("File", {"file_url": file_url})
+        file_url = BlobStore.get_file_link(file_name)
+        file_doc = frappe.db.exists("File", {"file_url": file_url})
 
-        # 2. Check permissions
-        if not file_doc.is_private:
-            # If for some reason a public file URL points here, just redirect
-            frappe.local.response["type"] = "redirect"
-            frappe.local.response["location"] = file_doc.file_url
-            return
+        if not file_doc:
+            raise frappe.DoesNotExistError
 
-        # This is Frappe's standard permission check for files
-        if not frappe.has_permission("File", "read", file_doc):
-            raise frappe.PermissionError
+        file_doc = frappe.get_doc("File", file_doc)
 
-        # 3. Ensure the file is actually in Azure
+        # 3. If file is local let frappe handle it.
         if BlobStore.is_local_file(file_doc.file_url):
-            raise frappe.ValidationError(_("This file is not stored on Azure."))
+            return download_private_file(file_doc.file_url)
+
+        if not file_doc.is_downloadable():
+            raise frappe.PermissionError
 
         # 4. Generate the SAS URL
         blob_store = BlobStore()
+
+        if file_doc.is_private:
+            container_name = blob_store.get_private_container_name()
+        else:
+            container_name = blob_store.get_public_container_name()
+
         # The blob_name is the cleaned file_name from the start of the function
-        sas_url = blob_store.generate_sas_url(
-            blob_name=file_name,
-            container_name=blob_store.get_private_container_name(),
-        )
+        sas_url = blob_store.generate_sas_url(blob_name=file_name, container_name=container_name)
 
         # 5. Redirect the user to the temporary URL
         frappe.local.response["type"] = "redirect"
         frappe.local.response["location"] = sas_url
 
-    except frappe.DoesNotExistError:
-        frappe.throw(_("File not found."), frappe.NotFound)
-    except Exception as e:
+    except (frappe.DoesNotExistError, frappe.PermissionError):
+        raise
+    except Exception:
         frappe.log_error(title="Private File Download", message=frappe.get_traceback())
-        frappe.throw(_("Could not retrieve file. Error: {0}").format(str(e)))
+        frappe.throw(_("Something went wrong while downloading the file."))

--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -299,15 +299,13 @@ class BlobStore:
 
     def parse_url(self, file_url: str) -> str | None:
         """
-        Parses a Frappe/Azure file URL to extract its components.
+        Parses a Frappe/Azure file URL to extract the blob name.
 
         Args:
-            file_url: The URL of the file, which can be a private proxy URL
-                    or a direct public Azure Blob Storage URL.
+            file_url: The URL of the file (proxy /api/method/ format).
 
         Returns:
-            A dict containing (container_name, blob_name, is_private).
-            Returns None if the URL format is not recognized.
+            The blob name string, or None if the URL format is not recognized.
         """
         if not file_url:
             return None
@@ -321,17 +319,6 @@ class BlobStore:
             if blob_name:
                 return blob_name
 
-        # --- Handle Public Direct Azure URLs ---
-        # e.g., https://account.blob.core.windows.net/container/path/to/blob.pdf
-        elif self.settings.endpoint_suffix in parsed_url.netloc:
-            # Path will be like /container_name/path/to/blob.pdf
-            path_parts = parsed_url.path.strip("/").split("/")
-            if path_parts:
-                # The rest of the path is the blob name
-                blob_name = "/".join(path_parts[1:])
-                return blob_name
-
-        # If neither format matches
         return None
 
 

--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -45,25 +45,24 @@ class BlobStore:
         self.blob_service_client = blob_service_client or self._get_blob_service_client()
 
         # Ensure appropriate containers
-        self._ensure_container_exists(self.get_public_container_name(), is_public=True)
-        self._ensure_container_exists(self.get_private_container_name(), is_public=False)
+        self._ensure_container_exists(self.get_public_container_name())
+        self._ensure_container_exists(self.get_private_container_name())
 
     def get_public_container_name(self) -> str:
         """
-        Returns the name of the public container.
+        Returns the name of the container where public files are stored.
         """
-        return f"{self.settings.default_container_name}-public"
+        return f"{self.settings.default_container_name}-frappe-public"
 
     def get_private_container_name(self) -> str:
         """
-        Returns the name of the private container.
+        Returns the name of the container where private files are stored.
         """
-        return f"{self.settings.default_container_name}-private"
+        return f"{self.settings.default_container_name}-frappe-private"
 
-    def _ensure_container_exists(self, container_name: str, is_public: bool = False):
+    def _ensure_container_exists(self, container_name: str):
         """
         Create a container if it doesn't exist.
-        Set public access if requested.
         """
         try:
             container_client = self.blob_service_client.get_container_client(container_name)
@@ -73,9 +72,6 @@ class BlobStore:
             except ResourceExistsError:
                 # This is expected if the container is already there.
                 pass
-
-            if is_public:
-                container_client.set_container_access_policy(signed_identifiers={}, public_access="blob")
 
         except Exception as e:
             generate_error_log(
@@ -88,18 +84,16 @@ class BlobStore:
     def generate_sas_url(
         self,
         blob_name: str,
-        container_name: str | None = None,
+        container_name: str,
         ignore_cache: bool = False,
     ) -> str:
         """
         Generates a temporary SAS URL to allow read access to a private blob.
 
-        :param container_name: The name of the private container.
+        :param container_name: The name of the container.
         :param blob_name: The name of the blob.
         :return: A full URL with a SAS token for temporary access.
         """
-        if container_name is None:
-            container_name = self.get_private_container_name()
 
         blob_client = self.blob_service_client.get_blob_client(container=container_name, blob=blob_name)
         cache_key = f"azure_blob_sas_url::{container_name}::{blob_name}"
@@ -185,12 +179,12 @@ class BlobStore:
         file_name = regex.sub("", file_name)
         return file_name
 
-    def blob_key_generator(self, file_name, parent_doctype=None, parent_name=None, is_private=True):
+    def blob_key_generator(self, file_name, parent_doctype=None, parent_name=None):
         """
-        Generate keys for s3 objects uploaded with file name attached.
+        Generate keys for blob objects uploaded with file name attached.
         """
         # Check for custom key generator hook
-        hook_cmd = frappe.get_hooks().get("s3_key_generator")
+        hook_cmd = frappe.get_hooks().get("blob_key_generator")
         if hook_cmd:
             try:
                 custom_key = frappe.get_attr(hook_cmd[0])(
@@ -234,14 +228,16 @@ class BlobStore:
         file_key: str,
         file_path: str,
         file_content: bytes | None = None,
-        is_private: bool = True,
+        is_file_private: bool = True,
     ) -> str:
         """
         Uploads a file to Azure Blob Storage and returns the blob URL.
         """
         try:
             blob_client = self.blob_service_client.get_blob_client(
-                container=(self.get_public_container_name() if not is_private else self.get_private_container_name()),
+                container=(
+                    self.get_public_container_name() if not is_file_private else self.get_private_container_name()
+                ),
                 blob=file_key,
             )
 
@@ -249,7 +245,7 @@ class BlobStore:
             if file_content:
                 data_to_upload = file_content
             else:
-                with open(file_path, "rb") as f:
+                with open(file_path, "rb") as f:  # nosemgrep
                     data_to_upload = f.read()
 
             blob_client.upload_blob(
@@ -260,7 +256,7 @@ class BlobStore:
                     content_disposition=f"inline; filename={quote(os.path.basename(file_path))}",
                 ),
             )
-            return blob_client.url if not is_private else self.get_private_file_link(file_key)
+            return self.get_file_link(file_key)
         except AzureError as e:
             generate_error_log(
                 _("Azure Blob Upload Error"),
@@ -289,19 +285,19 @@ class BlobStore:
             raise e
 
     @classmethod
-    def get_private_file_link(cls, file_key: str) -> str:
+    def get_file_link(cls, file_key: str) -> str:
         """
         Returns a temporary link to a private file stored in Azure Blob Storage.
         """
         # NOTE: It is better to provide the entire URL to the API method since Frappe internally
         # checks if the URL starts with `http` and handles operations accordingly.
-        return f"{frappe.utils.get_url()}/api/method/frappe_azure_blob_storage.api.azure_blob.download_private_file?file_name={quote(file_key)}"
+        return f"{frappe.utils.get_url()}/api/method/frappe_azure_blob_storage.api.azure_blob.download_file?file_name={file_key}"
 
     @classmethod
     def is_local_file(cls, file_url: str) -> bool:
         return file_url.startswith(("/files/", "/private/files/"))
 
-    def parse_url(self, file_url: str) -> frappe._dict | None:
+    def parse_url(self, file_url: str) -> str | None:
         """
         Parses a Frappe/Azure file URL to extract its components.
 
@@ -318,18 +314,12 @@ class BlobStore:
 
         parsed_url = urlparse(file_url)
 
-        # --- Handle Private Proxy URLs ---
-        # e.g., /api/method/...?file_name=container/path/to/blob.pdf
         if "/api/method/" in parsed_url.path:
             query_params = parse_qs(parsed_url.query)
             blob_name = query_params.get("file_name", [None])[0]
 
             if blob_name:
-                return frappe._dict(
-                    container_name=self.get_private_container_name(),
-                    blob_name=blob_name,
-                    is_private=True,
-                )
+                return blob_name
 
         # --- Handle Public Direct Azure URLs ---
         # e.g., https://account.blob.core.windows.net/container/path/to/blob.pdf
@@ -337,14 +327,9 @@ class BlobStore:
             # Path will be like /container_name/path/to/blob.pdf
             path_parts = parsed_url.path.strip("/").split("/")
             if path_parts:
-                container_name = path_parts[0]
                 # The rest of the path is the blob name
                 blob_name = "/".join(path_parts[1:])
-                return frappe._dict(
-                    container_name=container_name,
-                    blob_name=blob_name,
-                    is_private=False,
-                )
+                return blob_name
 
         # If neither format matches
         return None
@@ -364,8 +349,8 @@ def change_file_privacy(
         private_container = blob_store.get_private_container_name()
         public_container = blob_store.get_public_container_name()
 
-        blob_details = blob_store.parse_url(prev_url)
-        if not blob_details:
+        blob_name = blob_store.parse_url(prev_url)
+        if not blob_name:
             generate_error_log(
                 "File URL parsing failed",
                 f"Failed to parse file URL: {prev_url}",
@@ -374,7 +359,7 @@ def change_file_privacy(
             raise frappe.ValidationError(f"Cannot change privacy for file {prev_url}: Invalid file URL.")
 
         # keep the name same for both source and destination
-        source_blob_key = destination_blob_key = blob_details.blob_name
+        source_blob_key = destination_blob_key = blob_name
 
         if to_private:
             src_container, dest_container = public_container, private_container
@@ -418,10 +403,7 @@ def change_file_privacy(
 
         # Remove the cached SAS URL for the source blob
         frappe.cache().delete_value(f"azure_blob_sas_url::{src_container}::{source_blob_key}")
-        file_doc.set(
-            "file_url",
-            (destination_client.url if not to_private else blob_store.get_private_file_link(destination_blob_key)),
-        )
+        file_doc.set("file_url", blob_store.get_file_link(destination_blob_key))
         file_doc.is_private = to_private
         file_doc.save()
     except Exception as e:
@@ -468,7 +450,6 @@ def upload_local_file(
         file_name = file_doc.file_name
         parent_doctype = file_doc.attached_to_doctype
         parent_name = file_doc.attached_to_name
-        is_private = file_doc.is_private
         file_url = file_doc.file_url
 
         if not file_url:
@@ -478,14 +459,14 @@ def upload_local_file(
                 throw_exc=True,
             )
 
-        file_blob_key = blob_store.blob_key_generator(file_name, parent_doctype, parent_name, is_private)
+        file_blob_key = blob_store.blob_key_generator(file_name, parent_doctype, parent_name)
         full_file_path = get_file_path(file_id if file_id else file_doc.file_url)
 
         blob_url = blob_store.upload_blob(
             file_key=file_blob_key,
             file_content=file_doc.get_content() if file_doc else None,
             file_path=full_file_path,
-            is_private=is_private,
+            is_file_private=file_doc.is_private if file_doc else True,
         )
         if remove_original or (remove_original is None and blob_store.settings.remove_original_files == 1):
             if file_id:

--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import time
@@ -7,6 +8,8 @@ from urllib.parse import parse_qs, quote, urlparse
 
 import frappe
 import magic
+
+logging.getLogger("azure").setLevel(logging.WARNING)
 from azure.core.exceptions import AzureError, ResourceExistsError
 from azure.storage.blob import (
     BlobSasPermissions,

--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -203,19 +203,8 @@ class BlobStore:
 
         file_name = self.strip_special_chars(frappe.scrub(file_name))
         unique_key = frappe.generate_hash(length=8)
-        today = frappe.utils.now_datetime()
-        year, month, day = (
-            today.strftime("%Y"),
-            today.strftime("%m"),
-            today.strftime("%d"),
-        )
 
         path_parts = [
-            year,
-            month,
-            day,
-            parent_doctype,
-            parent_name,
             unique_key,
             file_name,
         ]

--- a/frappe_azure_blob_storage/blob_controllers/blob_store.py
+++ b/frappe_azure_blob_storage/blob_controllers/blob_store.py
@@ -234,6 +234,9 @@ class BlobStore:
         Uploads a file to Azure Blob Storage and returns the blob URL.
         """
         try:
+            if not self.settings.auto_upload_to_azure:
+                return file_path
+
             blob_client = self.blob_service_client.get_blob_client(
                 container=(
                     self.get_public_container_name() if not is_file_private else self.get_private_container_name()
@@ -297,6 +300,11 @@ class BlobStore:
     def is_local_file(cls, file_url: str) -> bool:
         return file_url.startswith(("/files/", "/private/files/"))
 
+    def is_ignored_dtype(self, doctype: str) -> bool:
+        ignored_dtypes = self.settings.ignored_doctypes or []
+        ignored_dtypes = [dtype._doctype.strip() for dtype in ignored_dtypes if dtype._doctype.strip()]
+        return doctype in ignored_dtypes
+
     def parse_url(self, file_url: str) -> str | None:
         """
         Parses a Frappe/Azure file URL to extract its components.
@@ -344,6 +352,8 @@ def change_file_privacy(
     Moves a blob from one location to another within Azure Blob Storage.
     """
     file_doc = frappe.get_doc("File", file_id)
+    if not file_doc.custom_uploaded_to_azure:
+        return
     try:
         blob_store = BlobStore()
         private_container = blob_store.get_private_container_name()
@@ -430,7 +440,7 @@ def upload_local_file(
     file_doc: File | None = None,
     file_id: str | None = None,
     remove_original: bool | None = None,
-) -> None:
+) -> File | None:
     """
     Uploads an existing file to Azure Blob Storage.
 
@@ -446,6 +456,13 @@ def upload_local_file(
 
         if file_id is not None:
             file_doc = frappe.get_doc("File", file_id)
+
+        if (
+            file_doc.custom_uploaded_to_azure
+            or blob_store.is_ignored_dtype(file_doc.attached_to_doctype)
+            or not blob_store.settings.auto_upload_to_azure
+        ):
+            return file_doc
 
         file_name = file_doc.file_name
         parent_doctype = file_doc.attached_to_doctype

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -29,6 +29,7 @@ def on_update(doc, method):
         doc.flags.in_insert  # ignore if this is a new file being inserted
         or not doc.has_value_changed("is_private")
         or BlobStore.is_local_file(doc.file_url)
+        or BlobStore.is_ignored_dtype(doc.attached_to_doctype)
     ):
         return
 
@@ -67,6 +68,10 @@ def on_trash(doc, method):
         return
 
     blob_store = BlobStore()
+
+    if blob_store.is_ignored_dtype(doc.attached_to_doctype):
+        return
+
     blob_name = blob_store.parse_url(doc.file_url)
     if not blob_name:
         generate_error_log(

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -33,8 +33,8 @@ def on_update(doc, method):
         return
 
     blob_store = BlobStore()
-    blob_details = blob_store.parse_url(doc.file_url)
-    if not blob_details:
+    blob_name = blob_store.parse_url(doc.file_url)
+    if not blob_name:
         generate_error_log(
             "File URL parsing failed",
             f"Failed to parse file URL: {doc.file_url}",
@@ -44,7 +44,7 @@ def on_update(doc, method):
 
     prev_url = doc.file_url
     # Generate a placeholder URL for the file while it is being moved
-    frappe.db.set_value("File", doc.name, "file_url", blob_store.get_private_file_link("in-transit"))
+    frappe.db.set_value("File", doc.name, "file_url", blob_store.get_file_link("in-transit"))
 
     frappe.enqueue(
         change_file_privacy,
@@ -67,12 +67,15 @@ def on_trash(doc, method):
         return
 
     blob_store = BlobStore()
-    blob_details = blob_store.parse_url(doc.file_url)
-    if not blob_details:
+    blob_name = blob_store.parse_url(doc.file_url)
+    if not blob_name:
         generate_error_log(
             "File URL parsing failed",
             f"Failed to parse file URL: {doc.file_url}",
             exception=frappe.get_traceback(),
         )
         raise frappe.ValidationError(f"Cannot delete file {doc.file_url}: Invalid file URL.")
-    blob_store.delete_blob(container_name=blob_details.container_name, blob_name=blob_details.blob_name)
+    container_name = (
+        blob_store.get_private_container_name() if doc.is_private else blob_store.get_public_container_name()
+    )
+    blob_store.delete_blob(container_name=container_name, blob_name=blob_name)

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -25,11 +25,12 @@ def on_update(doc, method):
     Event handler for the 'on_update' event of the File document.
     This function is used to update the File URL if the file is stored in Azure Blob Storage.
     """
+    blob_store = BlobStore()
     if (
         doc.flags.in_insert  # ignore if this is a new file being inserted
         or not doc.has_value_changed("is_private")
         or BlobStore.is_local_file(doc.file_url)
-        or BlobStore.is_ignored_dtype(doc.attached_to_doctype)
+        or blob_store.is_ignored_dtype(doc.attached_to_doctype)
     ):
         return
 

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -25,16 +25,17 @@ def on_update(doc, method):
     Event handler for the 'on_update' event of the File document.
     This function is used to update the File URL if the file is stored in Azure Blob Storage.
     """
-    blob_store = BlobStore()
     if (
         doc.flags.in_insert  # ignore if this is a new file being inserted
         or not doc.has_value_changed("is_private")
         or BlobStore.is_local_file(doc.file_url)
-        or blob_store.is_ignored_dtype(doc.attached_to_doctype)
     ):
         return
 
     blob_store = BlobStore()
+    if blob_store.is_ignored_dtype(doc.attached_to_doctype):
+        return
+
     blob_name = blob_store.parse_url(doc.file_url)
     if not blob_name:
         generate_error_log(

--- a/frappe_azure_blob_storage/doc_events/file.py
+++ b/frappe_azure_blob_storage/doc_events/file.py
@@ -32,6 +32,9 @@ def on_update(doc, method):
     ):
         return
 
+    settings = frappe.get_single("Azure Storage Settings")
+    if not settings.auto_upload_to_azure:
+        return
     blob_store = BlobStore()
     if blob_store.is_ignored_dtype(doc.attached_to_doctype):
         return

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctyoe/azure_storage_ignored_doctyoe.json
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctyoe/azure_storage_ignored_doctyoe.json
@@ -1,0 +1,37 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-04-06 07:16:49.845093",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "_doctype"
+ ],
+ "fields": [
+  {
+   "fieldname": "_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "DocType",
+   "options": "DocType",
+   "reqd": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-04-06 07:17:40.925356",
+ "modified_by": "Administrator",
+ "module": "Frappe Azure Blob Storage",
+ "name": "Azure Storage Ignored DocTyoe",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctyoe/azure_storage_ignored_doctyoe.py
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctyoe/azure_storage_ignored_doctyoe.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, rtCamp and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class AzureStorageIgnoredDocTyoe(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        _doctype: DF.Link
+        parent: DF.Data
+        parentfield: DF.Data
+        parenttype: DF.Data
+    # end: auto-generated types
+
+    pass

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctype/azure_storage_ignored_doctype.json
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctype/azure_storage_ignored_doctype.json
@@ -25,7 +25,7 @@
  "modified": "2026-04-06 07:17:40.925356",
  "modified_by": "Administrator",
  "module": "Frappe Azure Blob Storage",
- "name": "Azure Storage Ignored DocTyoe",
+ "name": "Azure Storage Ignored DocType",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctype/azure_storage_ignored_doctype.py
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_ignored_doctype/azure_storage_ignored_doctype.py
@@ -5,7 +5,7 @@
 from frappe.model.document import Document
 
 
-class AzureStorageIgnoredDocTyoe(Document):
+class AzureStorageIgnoredDocType(Document):
     # begin: auto-generated types
     # This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.js
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.js
@@ -2,52 +2,50 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Azure Storage Settings", {
-	refresh: function (frm) {
-		if (!frm.is_new()) {
-			frm.add_custom_button(__("Migrate Files"), () => {
-				frm.events.migrate_files(frm);
-			});
-		}
-	},
+  refresh: function (frm) {
+    if (!frm.is_new()) {
+      frm.add_custom_button(__("Migrate Files"), () => {
+        frm.events.migrate_files(frm);
+      });
+    }
+  },
 
-	check_connection: function (frm) {
-		frm.call({
-			method: "frappe_azure_blob_storage.api.azure_blob.test_connection",
-			type: "GET",
-			callback: function (r) {
-				if (r.success === true) {
-					frappe.show_alert({
-						message: __(r.message),
-						indicator: "green",
-					});
-				} else {
-					frappe.show_alert({
-						message: __(
-							"Invalid credentials! Please check your Azure Storage Settings."
-						),
-						indicator: "red",
-					});
-				}
-			},
-		});
-	},
-	migrate_files: function (frm) {
-		frm.call({
-			method: "frappe_azure_blob_storage.api.azure_blob.migrate_files",
-			type: "GET",
-			callback: function (r) {
-				if (r.success === true) {
-					frappe.show_alert({
-						message: __("Migration started successfully!"),
-						indicator: "green",
-					});
-				} else {
-					frappe.show_alert({
-						message: __("Error: " + r.message),
-						indicator: "red",
-					});
-				}
-			},
-		});
-	},
+  check_connection: function (frm) {
+    frm.call({
+      method: "frappe_azure_blob_storage.api.azure_blob.test_connection",
+      type: "GET",
+      callback: function (r) {
+        if (r.success === true) {
+          frappe.show_alert({
+            message: __(r.message),
+            indicator: "green",
+          });
+        } else {
+          frappe.show_alert({
+            message: __(r.message),
+            indicator: "red",
+          });
+        }
+      },
+    });
+  },
+  migrate_files: function (frm) {
+    frm.call({
+      method: "frappe_azure_blob_storage.api.azure_blob.migrate_files",
+      type: "GET",
+      callback: function (r) {
+        if (r.success === true) {
+          frappe.show_alert({
+            message: __("Migration started successfully!"),
+            indicator: "green",
+          });
+        } else {
+          frappe.show_alert({
+            message: __("Error: " + r.message),
+            indicator: "red",
+          });
+        }
+      },
+    });
+  },
 });

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.json
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.json
@@ -13,6 +13,7 @@
   "column_break_gngc",
   "endpoint_suffix",
   "default_container_name",
+  "ignored_doctypes",
   "credentials_section",
   "connection_string",
   "access_key",
@@ -112,13 +113,20 @@
    "fieldname": "auto_upload_to_azure",
    "fieldtype": "Check",
    "label": "Auto Upload to Azure"
+  },
+  {
+   "description": "DocTypes to ignore when uploading files to blob storage.",
+   "fieldname": "ignored_doctypes",
+   "fieldtype": "Table MultiSelect",
+   "label": "Ignored DocTypes",
+   "options": "Azure Storage Ignored DocTyoe"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-07 16:38:39.958306",
+ "modified": "2026-04-06 07:18:45.495485",
  "modified_by": "Administrator",
  "module": "Frappe Azure Blob Storage",
  "name": "Azure Storage Settings",

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.json
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.json
@@ -119,14 +119,14 @@
    "fieldname": "ignored_doctypes",
    "fieldtype": "Table MultiSelect",
    "label": "Ignored DocTypes",
-   "options": "Azure Storage Ignored DocTyoe"
+   "options": "Azure Storage Ignored DocType"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-06 07:18:45.495485",
+ "modified": "2026-04-13 04:51:42.679077",
  "modified_by": "Administrator",
  "module": "Frappe Azure Blob Storage",
  "name": "Azure Storage Settings",

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.py
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.py
@@ -14,8 +14,8 @@ class AzureStorageSettings(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        from frappe_azure_blob_storage.frappe_azure_blob_storage.doctype.azure_storage_ignored_doctyoe.azure_storage_ignored_doctyoe import (
-            AzureStorageIgnoredDocTyoe,
+        from frappe_azure_blob_storage.frappe_azure_blob_storage.doctype.azure_storage_ignored_doctype.azure_storage_ignored_doctype import (
+            AzureStorageIgnoredDocType,
         )
 
         access_key: DF.Password | None
@@ -24,7 +24,7 @@ class AzureStorageSettings(Document):
         connection_string: DF.Password | None
         default_container_name: DF.Data
         endpoint_suffix: DF.Data
-        ignored_doctypes: DF.TableMultiSelect[AzureStorageIgnoredDocTyoe]
+        ignored_doctypes: DF.TableMultiSelect[AzureStorageIgnoredDocType]
         remove_original_files: DF.Check
         sas_token_validity: DF.Int
         storage_account_name: DF.Data

--- a/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.py
+++ b/frappe_azure_blob_storage/frappe_azure_blob_storage/doctype/azure_storage_settings/azure_storage_settings.py
@@ -6,6 +6,30 @@ from frappe.model.document import Document
 
 
 class AzureStorageSettings(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from frappe_azure_blob_storage.frappe_azure_blob_storage.doctype.azure_storage_ignored_doctyoe.azure_storage_ignored_doctyoe import (
+            AzureStorageIgnoredDocTyoe,
+        )
+
+        access_key: DF.Password | None
+        authentication_method: DF.Literal["Connection String", "Access Key"]
+        auto_upload_to_azure: DF.Check
+        connection_string: DF.Password | None
+        default_container_name: DF.Data
+        endpoint_suffix: DF.Data
+        ignored_doctypes: DF.TableMultiSelect[AzureStorageIgnoredDocTyoe]
+        remove_original_files: DF.Check
+        sas_token_validity: DF.Int
+        storage_account_name: DF.Data
+    # end: auto-generated types
+
     def validate(self):
         """
         Validate the Azure Storage Settings document.

--- a/frappe_azure_blob_storage/hooks.py
+++ b/frappe_azure_blob_storage/hooks.py
@@ -129,9 +129,9 @@ app_license = "agpl-3.0"
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-#     "File": "frappe_azure_blob_storage.doc_events.file.OverrideFile",
-# }
+override_doctype_class = {
+    "File": "frappe_azure_blob_storage.overrides.file.FileOverride",
+}
 
 # Document Events
 # ---------------

--- a/frappe_azure_blob_storage/overrides/file.py
+++ b/frappe_azure_blob_storage/overrides/file.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe.core.doctype.file.file import File
+
+
+class FileOverride(File):
+    def get_content(self, encodings=None) -> bytes | str:
+        if hasattr(self, "custom_uploaded_to_azure") and not self.custom_uploaded_to_azure:
+            return super().get_content(encodings=encodings)
+        if self.is_folder:
+            frappe.throw(frappe._("Cannot get file contents of a Folder"))
+
+        from frappe_azure_blob_storage.blob_controllers.blob_store import BlobStore
+
+        blob_store = BlobStore()
+        blob_name = blob_store.parse_url(self.file_url)
+
+        if not blob_name:
+            frappe.throw(frappe._("Could not extract file name from URL: {0}").format(self.file_url))
+
+        container_name = (
+            blob_store.get_private_container_name() if self.is_private else blob_store.get_public_container_name()
+        )
+
+        blob_client = blob_store.blob_service_client.get_blob_client(container=container_name, blob=blob_name)
+        return blob_client.download_blob().readall()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
     "azure-storage-blob~=12.28.0",
-    "azure-identity~=1.23.1",
+    "azure-identity~=1.25.1",
     "python-magic~=0.4.27",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.bench.frappe-dependencies]
-frappe = ">=15.40.4,<17.0.0"
+frappe = ">=16.0.0,<17.0.0"
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # "frappe~=15.0.0" # Installed and managed by bench.
-    "azure-storage-blob~=12.26.0",
+    "azure-storage-blob~=12.28.0",
     "azure-identity~=1.23.1",
     "python-magic~=0.4.27",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "rtCamp", email = "frappe@rtcamp.com"}
 ]
 description = "Blob Storage support for Azure"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
@@ -18,13 +18,15 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.40.4,<17.0.0"
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py314"
 exclude = [
     "**/doctype/*/boilerplate/*.py", # boilerplate are template strings, not valid python
 ]


### PR DESCRIPTION
## Description

This PR brings significant upgrades to the Azure Blob Storage integration, ensuring compatibility with Frappe v16 and Python 3.14, improving file retrieval mechanisms, and giving administrators more granular control over what gets uploaded to the cloud.

**Key Changes:**
1. **Ignored DocTypes**: Introduced a new setting in `Azure Storage Settings` called `ignored_doctypes`. Administrators can now specify specific DocTypes (via a multi-select table) whose file attachments should remain local and *not* be synced to Azure Blob Storage.
2. **Core File Override (`get_content`)**: Overrode Frappe's core `File` DocType to intercept the `get_content()` method. Previously, Frappe would attempt to read Azure files from the local disk, causing `FileNotFound` errors (e.g., when trying to attach them to emails). The override now correctly downloads the file buffer directly from Azure via the Python SDK.
3. **Unified Download API**: Refactored the `download_private_file` API to `download_file` (allowing guest access where appropriate). It now acts as a secure, unified proxy capable of serving both public and private files, falling back to Frappe's standard local file handler if the file isn't in Azure.
4. **CI/CD & Dependency Bumps**: 
   * Added `.github/dependabot.yml` to automate dependency updates across multiple ecosystems (pip, npm, docker, github-actions, etc.).
   * Bumped Python requirement to `>=3.14` and Frappe to `>=16.0.0,<17.0.0`. 
   * Updated `azure-storage-blob`, `azure-identity`, `ruff`, and `semgrep-ci` versions.

## Relevant Technical Choices

* **Blob Key Generation**: Simplified the `blob_key_generator`. It no longer nests files deeply into `YYYY/MM/DD/doctype/docname/` folders. It now simply uses `unique_key/file_name`. The custom hook reference was also renamed from `s3_key_generator` to `blob_key_generator`.
* **Container Naming Rules**: Updated `get_public_container_name` and `get_private_container_name` to append `-frappe-public` and `-frappe-private` suffixes to the default container name (rather than just `-public` and `-private`).
* **URL Parsing**: Refactored `BlobStore.parse_url()` to only return the extracted `blob_name` string instead of a dictionary. The responsibility of determining the correct container (public vs. private) was shifted to the respective calling functions, simplifying the core utility.
* **Upload Guards**: Added early exit clauses in `upload_local_file`, `on_update`, and `on_trash` doc events to instantly return if `auto_upload_to_azure` is disabled or if the file belongs to an ignored DocType.

## Testing Instructions

1. **Verify Ignored DocTypes:**
   * Navigate to **Azure Storage Settings** and add a DocType (e.g., `ToDo`) to the **Ignored DocTypes** table.
   * Upload a file and attach it to a `ToDo` record.
   * **Verify:** The file should be saved to the local file system (check the `file_url`), and the Azure Blob Storage containers should not contain this new file.
2. **Verify File Content Override (`get_content`):**
   * Upload a file to a non-ignored DocType so it correctly uploads to Azure.
   * Open the Frappe python console (`bench console`) and fetch the file doc: `doc = frappe.get_doc("File", "<your_file_id>")`
   * Run `doc.get_content()`.
   * **Verify:** It should successfully return the byte string of the file without throwing a local `FileNotFoundError`. (Alternatively, test this by attaching an Azure-hosted file to an outgoing Email in the desk).
3. **Verify Download API:**
   * Find both a public and a private file stored on Azure.
   * Click the download/view link in the Frappe Desk for both.
   * **Verify:** Both files should successfully resolve and download via the SAS URL redirect.
4. **General Operations:**
   * **Verify:** Deleting a file in Frappe successfully triggers the `on_trash` hook and removes the blob from Azure.

## Additional Information:

* **Action Required:** After pulling these changes, run `bench migrate` to install the new `Azure Storage Ignored DocType` schema and apply the settings updates.

## Screenshot/Screencast

N/A

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)